### PR TITLE
-die zuletzt eingegebene erfolgreich eingeloggte E-Mail Adresse wird n…

### DIFF
--- a/app/src/main/java/de/codematch/naoray/media_player_app/LoginActivityOriginal.java
+++ b/app/src/main/java/de/codematch/naoray/media_player_app/LoginActivityOriginal.java
@@ -80,6 +80,10 @@ public class LoginActivityOriginal extends AppCompatActivity {
         // calling DatabaseManager to Init DB
         db = new DatabaseManager(this);
 
+        mEmailView.setText(spref.getString(getString(R.string.E_Mail_Address_preferences_key), ""));
+        if (!mEmailView.getText().toString().equals("")) {
+            mPasswordView.requestFocus();
+        }
         mKeepMeLoggedInCheckBox = (CheckBox) findViewById(R.id.stay_logged);
         //restores the status of the keepmeloggedin checkbox
         if (spref.getBoolean("KeepMeLoggedIn", false)) {
@@ -347,6 +351,9 @@ public class LoginActivityOriginal extends AppCompatActivity {
             mAuthTask = null;
 
             if (success) {
+                editor.putString(getString(R.string.E_Mail_Address_preferences_key), mEmail);
+                editor.apply();
+
                 finish();
                 this.addEmailToAutocompleteList();
                 if (keepMeLoggedInChecked) {

--- a/app/src/main/java/de/codematch/naoray/media_player_app/MainMenueActivity.java
+++ b/app/src/main/java/de/codematch/naoray/media_player_app/MainMenueActivity.java
@@ -56,8 +56,8 @@ public class MainMenueActivity extends AppCompatActivity {
         // Auf die SharedPreferences-Datei sollte nur lesend zugegriffen werden.Das Speichern übernimmt das Android System.
         // Liest die Default SharedPreferences-Datei ein und ließt den Wert, der vom passenden Key (Key-Value-Paare) referenziert wird aus
         sPrefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-        String benutzernamePreferencesKey = getString(R.string.benutzername_preferences_key);
-        String benutzernamePreferencesDefault = getString(R.string.benutzername_preferences_default);
+        String benutzernamePreferencesKey = getString(R.string.E_Mail_Address_preferences_key);
+        String benutzernamePreferencesDefault = "";
         String aktuellerBenutzername = sPrefs.getString(benutzernamePreferencesKey, benutzernamePreferencesDefault);
 
         String wunschtext = getString(R.string.wunschtext);

--- a/app/src/main/java/de/codematch/naoray/media_player_app/SettingsActivity.java
+++ b/app/src/main/java/de/codematch/naoray/media_player_app/SettingsActivity.java
@@ -4,10 +4,10 @@ package de.codematch.naoray.media_player_app;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
+import android.preference.PreferenceFragment;
 import android.support.v4.app.NavUtils;
 import android.support.v7.app.ActionBar;
 import android.view.MenuItem;
-import android.widget.Toast;
 
 /**
  * A {@link PreferenceActivity} that presents a set of application settings. On
@@ -20,17 +20,17 @@ import android.widget.Toast;
  * href="http://developer.android.com/guide/topics/ui/settings.html">Settings
  * API Guide</a> for more information on developing a Settings UI.
  */
-public class SettingsActivity extends AppCompatPreferenceActivity implements Preference.OnPreferenceChangeListener {
+public class SettingsActivity extends AppCompatPreferenceActivity {
 
     private Preference benutzernamePreference;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        addPreferencesFromResource(R.xml.preferences);
+        //addPreferencesFromResource(R.xml.preferences);
+        getFragmentManager().beginTransaction().replace(android.R.id.content,
+                new PrefsFragment()).commit();
         setupActionBar();
-        benutzernamePreference = findPreference(getString(R.string.benutzername_preferences_key));
-        benutzernamePreference.setOnPreferenceChangeListener(this);
     }
 
     /**
@@ -57,7 +57,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity implements Pre
         return super.onMenuItemSelected(featureId, item);
     }
 
-    //Mit dem Rückgabewert "true" wird die Einstellung übernommen, mit "false" wird sie verworfen
+/*    //Mit dem Rückgabewert "true" wird die Einstellung übernommen, mit "false" wird sie verworfen
     @Override
     public boolean onPreferenceChange(Preference preference, Object object) {
         if (preference == benutzernamePreference) {
@@ -72,6 +72,18 @@ public class SettingsActivity extends AppCompatPreferenceActivity implements Pre
         } else {
             return false;
         }
+    }*/
+
+    public static class PrefsFragment extends PreferenceFragment {
+
+        @Override
+        public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+
+            // Load the preferences from an XML resource
+            addPreferencesFromResource(R.xml.preferences);
+        }
+
     }
 }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -27,9 +27,7 @@
     <string name="menu_item_einstellungen">Einstellungen</string>
     <string name="menu_item_hilfe">Hilfe</string>
 
-    <string name="benutzername_preferences_title">Benutzername</string>
-    <string name="benutzername_preferences_key">Benutzername Key</string>
-    <string name="benutzername_preferences_default">Nico Weber</string>
+    <string name="E_Mail_Address_preferences_key">E-Mail Key</string>
     <string name="landscape_preferences_key">Landscape Key</string>
     <string name="landscape_preferences_title">Videos nur im Querformat</string>
     <string name="title_activity_settings">Einstellungen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,9 +25,7 @@
     <string name="menu_item_einstellungen">Settings</string>
     <string name="menu_item_hilfe">Help</string>
 
-    <string name="benutzername_preferences_title">Username</string>
-    <string name="benutzername_preferences_key">Benutzername Key</string>
-    <string name="benutzername_preferences_default">Nico Weber</string>
+    <string name="E_Mail_Address_preferences_key">E-Mail Key</string>
     <string name="landscape_preferences_key">Landscape Key</string>
     <string name="landscape_preferences_title">Videos only in landscape mode</string>
     <string name="title_activity_settings">Settings</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <EditTextPreference
-        android:defaultValue="@string/benutzername_preferences_default"
-        android:icon="@drawable/ic_info_black_24dp"
-        android:inputType="text"
-        android:key="@string/benutzername_preferences_key"
-        android:maxLength="20"
-        android:singleLine="true"
-        android:title="@string/benutzername_preferences_title" />
-
     <SwitchPreference
         android:disableDependentsState="false"
         android:icon="@mipmap/ic_stay_current_landscape_black_24dp"


### PR DESCRIPTION
…un komplett im E-Mail Feld behalten und es wird dann automatisch das Passwort-Feld in den Fokus gerückt, ansonsten leeres E-Mail Feld

-Benutzernamen-Preference wurde aus den Einstellungen entfernt

-für das Laden der Preferences wird nun ein Preference-Fragment benutzt, da die alte Methode "deprecated" war und nicht mehr benutzt werden sollte
